### PR TITLE
Add option to print logs from successful process

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ Keys in the `watch` object should be [globs](https://www.npmjs.com/package/glob)
 names as specified in `scripts`.
 
 Now you can start the file watcher using `npm run watch`.
+
+### Option(s)
+
+The default behaviour is to pass logs along _only_ if the exit code for a build is not `0`. You can change this and show all logs by passing a `-v`(or `--verbose`) flag in your package.json:
+
+```js
+{
+  ...
+  "watch": "npm-scripts-watcher -v"
+  ...
+}
+```

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -9,6 +9,8 @@ import shell from 'shelljs';
 const cwd = process.cwd();
 const config = require(path.join(cwd, 'package.json'));
 
+const verbose = (['--verbose', '-v'].indexOf(process.argv[2]) !== -1);
+
 Object.keys(config.watch).forEach(pattern => {
   glob(pattern, { cwd }, (err, files) => {
     if (err) {
@@ -39,6 +41,7 @@ function run(name, script, command) {
   shell.exec(command, { silent: true }, (exitcode, output) => {
     if (exitcode === 0) {
       console.log('✓'.green, name.bold, script.gray);
+      verbose && console.log(output.trim().gray);
     } else {
       console.log('✗'.red, name.bold, script.gray);
       console.log(output.trim().gray);


### PR DESCRIPTION
## Changes

Allows user to pass a `--verbose` option to npm-scripts-watcher, so that logs for a successful build process (exit code == 0) are not hidden.

## Motivation

I was (reasonably) bothered by the same point described [in this issue](https://github.com/wehkamp/npm-scripts-watcher/issues/1).

I don’t know if you deliberately discarded this possibility or didn’t like the implementation alternatives or just didn’t have time. Feel free to merge or not.